### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for analyzing and optimizing WebGL games. This server provides tools to analyze WebGL applications, optimize performance, and provide insights into WebGL-based games and applications.
 
+<a href="https://glama.ai/mcp/servers/l5zh0e3z4x">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/l5zh0e3z4x/badge" alt="WebGL-Server MCP server" />
+</a>
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP: v1.0](https://img.shields.io/badge/MCP-v1.0-blue.svg)](https://modelcontextprotocol.io/)
 
@@ -278,4 +282,4 @@ MIT
 
 Grokade Games - [Website](https://grokadegames.com)
 
-Project Link: [https://github.com/grokadegames/webgl-mcp](https://github.com/grokadegames/webgl-mcp) 
+Project Link: [https://github.com/grokadegames/webgl-mcp](https://github.com/grokadegames/webgl-mcp)


### PR DESCRIPTION
This PR adds a badge for the [WebGL-MCP Server](https://glama.ai/mcp/servers/l5zh0e3z4x) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/l5zh0e3z4x">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/l5zh0e3z4x/badge" alt="WebGL-Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.